### PR TITLE
link fix for Domains & Competencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Prometheus Certified Associate Beta exam
 
 - [Candidate Handbook](https://docs.linuxfoundation.org/tc-docs/certification/lf-handbook2)
 - [Important Instructions to PCA](https://docs.linuxfoundation.org/tc-docs/certification/important-instructions-pca)
-- [Domains & Competencies](https://github.com/cncf/curriculum/blob/master/Prometheus_Curriculum.pdf)
+- [Domains & Competencies](https://github.com/cncf/curriculum/blob/master/PCA_Curriculum.pdf)
 - [Exam Details](https://www.cncf.io/certification/pca/)
 - [Check System Requirements](https://syscheck.bridge.psiexams.com/)
 


### PR DESCRIPTION
Clicking the "Domains & Competencies" hyperlink presently redirects to https://github.com/cncf/curriculum/blob/master/Prometheus_Curriculum.pdf which no longer exists.

So, changed the link to the new URL i.e. https://github.com/cncf/curriculum/blob/master/PCA_Curriculum.pdf

Please review.
Thanks.